### PR TITLE
pass workflow environment into the environment

### DIFF
--- a/.github/workflows/update-keys.yaml
+++ b/.github/workflows/update-keys.yaml
@@ -35,5 +35,5 @@ jobs:
           script: |
             git clone ${{ env.SSH_KEY_REPO }} /tmp/ssh-keys
             cd /tmp/ssh-keys
-            LOCAL_SSH_KEYS=${{ env.LOCAL_SSH_KEYS }} ./update_ssh_keys.sh
+            SSH_KEY_REPO=${{ env.SSH_KEY_REPO }} LOCAL_SSH_KEYS=${{ env.LOCAL_SSH_KEYS }} ./update_ssh_keys.sh
             rm -r /tmp/ssh-keys


### PR DESCRIPTION
doesn't really matter but it's better for clarity in the authorized_keys files